### PR TITLE
Tweak whitespace logic when nesting a comment

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -15,7 +15,7 @@ endfunction
 
 function! s:strip_white_space(l,r,line) abort
   let [l, r] = [a:l, a:r]
-  if l[-1:] ==# ' ' && stridx(a:line,l) == -1 && stridx(a:line,l[0:-2]) == 0
+  if l[-1:] ==# ' ' && stridx(a:line . ' ', l) == -1 && stridx(a:line, l[0:-2]) == 0
     let l = l[:-2]
   endif
   if r[0] ==# ' ' && (' ' . a:line)[-strlen(r)-1:] != r && a:line[-strlen(r):] == r[1:]


### PR DESCRIPTION
Resolves: https://github.com/tpope/vim-commentary/issues/175